### PR TITLE
Handle compressed response logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # HTTP proxy logger
-This is HTTP proxy which prints http requests and responses to console including http body.
+This is HTTP proxy which prints HTTP requests and responses to the console,
+including their bodies. Responses compressed with `gzip` or `deflate` are
+automatically decompressed in the logs for readability.
 For example:
 ```
 2021/05/05 03:50:44 ---REQUEST 3---


### PR DESCRIPTION
## Summary
- support decompressing gzip/deflate payloads for logging
- clarify in README that compressed bodies are decompressed in logs

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_684be78cb5e483329c296a2a22f5d222