### PR TITLE
Add body syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 HTTP Proxy Logger is a small reverse proxy that prints incoming HTTP requests
 and outgoing responses to stdout. Bodies compressed with `gzip` or `deflate`
 are automatically decompressed in the logs so that you can easily inspect them.
+The output uses ANSI colors similar to `HTTPie`: request and response lines,
+header names, and JSON or XML bodies are highlighted for readability.
 
 ## Example output
 

--- a/highlight.go
+++ b/highlight.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const (
+	colorReset     = "\033[0m"
+	colorKey       = "\033[36m"
+	colorString    = "\033[32m"
+	colorNumber    = "\033[33m"
+	colorBool      = "\033[35m"
+	colorNull      = "\033[90m"
+	colorPunct     = "\033[37m"
+	colorTag       = "\033[34m"
+	colorAttr      = "\033[33m"
+	colorMethod    = "\033[35m"
+	colorURL       = "\033[36m"
+	colorHeader    = "\033[34m"
+	colorStatus2xx = "\033[32m"
+	colorStatus3xx = "\033[36m"
+	colorStatus4xx = "\033[33m"
+	colorStatus5xx = "\033[31m"
+)
+
+func wrapColor(s, color string) string {
+	return color + s + colorReset
+}
+
+func highlightJSONValue(v interface{}, indent int) string {
+	switch t := v.(type) {
+	case map[string]interface{}:
+		var keys []string
+		for k := range t {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		var b strings.Builder
+		b.WriteString(colorPunct + "{" + colorReset + "\n")
+		indent++
+		for i, k := range keys {
+			b.WriteString(strings.Repeat("  ", indent))
+			b.WriteString(wrapColor("\""+k+"\"", colorKey))
+			b.WriteString(wrapColor(": ", colorPunct))
+			b.WriteString(highlightJSONValue(t[k], indent))
+			if i < len(keys)-1 {
+				b.WriteString(wrapColor(",", colorPunct))
+			}
+			b.WriteString("\n")
+		}
+		indent--
+		b.WriteString(strings.Repeat("  ", indent))
+		b.WriteString(colorPunct + "}" + colorReset)
+		return b.String()
+	case []interface{}:
+		var b strings.Builder
+		b.WriteString(colorPunct + "[" + colorReset + "\n")
+		indent++
+		for i, val := range t {
+			b.WriteString(strings.Repeat("  ", indent))
+			b.WriteString(highlightJSONValue(val, indent))
+			if i < len(t)-1 {
+				b.WriteString(wrapColor(",", colorPunct))
+			}
+			b.WriteString("\n")
+		}
+		indent--
+		b.WriteString(strings.Repeat("  ", indent))
+		b.WriteString(colorPunct + "]" + colorReset)
+		return b.String()
+	case string:
+		return wrapColor(strconv.Quote(t), colorString)
+	case float64:
+		return wrapColor(strconv.FormatFloat(t, 'f', -1, 64), colorNumber)
+	case bool:
+		return wrapColor(strconv.FormatBool(t), colorBool)
+	default:
+		return wrapColor("null", colorNull)
+	}
+}
+
+func highlightJSON(data []byte) string {
+	var v interface{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return string(data)
+	}
+	return highlightJSONValue(v, 0)
+}
+
+func highlightXML(data []byte) string {
+	dec := xml.NewDecoder(bytes.NewReader(data))
+	var b strings.Builder
+	indent := 0
+	for {
+		tok, err := dec.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return string(data)
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			b.WriteString(strings.Repeat("  ", indent))
+			b.WriteString(wrapColor("<"+t.Name.Local, colorTag))
+			for _, attr := range t.Attr {
+				b.WriteString(" ")
+				b.WriteString(wrapColor(attr.Name.Local, colorAttr))
+				b.WriteString(wrapColor("=", colorPunct))
+				b.WriteString(wrapColor("\""+attr.Value+"\"", colorString))
+			}
+			b.WriteString(wrapColor(">", colorTag))
+			b.WriteString("\n")
+			indent++
+		case xml.EndElement:
+			indent--
+			b.WriteString(strings.Repeat("  ", indent))
+			b.WriteString(wrapColor("</"+t.Name.Local+">", colorTag))
+			b.WriteString("\n")
+		case xml.CharData:
+			txt := strings.TrimSpace(string([]byte(t)))
+			if len(txt) > 0 {
+				b.WriteString(strings.Repeat("  ", indent))
+				b.WriteString(wrapColor(txt, colorString))
+				b.WriteString("\n")
+			}
+		case xml.Comment:
+			b.WriteString(strings.Repeat("  ", indent))
+			b.WriteString(wrapColor("<!--"+string(t)+"-->", colorNull))
+			b.WriteString("\n")
+		}
+	}
+	return b.String()
+}
+
+func highlightBody(data []byte, contentType string) []byte {
+	ct := strings.ToLower(contentType)
+	if strings.Contains(ct, "json") {
+		return []byte(highlightJSON(data))
+	}
+	if strings.Contains(ct, "xml") {
+		return []byte(highlightXML(data))
+	}
+	return data
+}
+
+func colorStatus(code int) string {
+	switch {
+	case code >= 200 && code < 300:
+		return colorStatus2xx
+	case code >= 300 && code < 400:
+		return colorStatus3xx
+	case code >= 400 && code < 500:
+		return colorStatus4xx
+	default:
+		return colorStatus5xx
+	}
+}
+
+func highlightHeaders(data []byte, isRequest bool) []byte {
+	lines := strings.Split(string(bytes.TrimSuffix(data, []byte("\r\n"))), "\r\n")
+	if len(lines) == 0 {
+		return data
+	}
+
+	if isRequest {
+		parts := strings.SplitN(lines[0], " ", 3)
+		if len(parts) == 3 {
+			lines[0] = wrapColor(parts[0], colorMethod) + " " + wrapColor(parts[1], colorURL) + " " + parts[2]
+		}
+	} else {
+		parts := strings.SplitN(lines[0], " ", 3)
+		if len(parts) >= 2 {
+			code, _ := strconv.Atoi(parts[1])
+			status := strings.Join(parts[1:], " ")
+			lines[0] = parts[0] + " " + wrapColor(status, colorStatus(code))
+		}
+	}
+
+	for i := 1; i < len(lines); i++ {
+		if lines[i] == "" {
+			break
+		}
+		kv := strings.SplitN(lines[i], ":", 2)
+		if len(kv) == 2 {
+			lines[i] = wrapColor(strings.TrimSpace(kv[0]), colorHeader) + ":" + wrapColor(kv[1], colorString)
+		}
+	}
+	return []byte(strings.Join(lines, "\r\n"))
+}

--- a/highlight_test.go
+++ b/highlight_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHighlightBodyJSON(t *testing.T) {
+	data := []byte(`{"name":"Alice"}`)
+	out := string(highlightBody(data, "application/json"))
+	if out == string(data) {
+		t.Fatalf("expected JSON body to be highlighted")
+	}
+	if !strings.Contains(out, colorKey) || !strings.Contains(out, colorString) {
+		t.Errorf("highlighted JSON missing colors: %q", out)
+	}
+}
+
+func TestHighlightBodyXML(t *testing.T) {
+	data := []byte(`<p>Hello</p>`)
+	out := string(highlightBody(data, "application/xml"))
+	if out == string(data) {
+		t.Fatalf("expected XML body to be highlighted")
+	}
+	if !strings.Contains(out, colorTag) {
+		t.Errorf("highlighted XML missing tag color: %q", out)
+	}
+}
+
+func TestHighlightHeadersRequest(t *testing.T) {
+	headers := []byte("POST /foo HTTP/1.1\r\nHost: example.com\r\n\r\n")
+	out := string(highlightHeaders(headers, true))
+	if !strings.Contains(out, colorMethod) || !strings.Contains(out, colorURL) {
+		t.Errorf("request line not highlighted: %q", out)
+	}
+	if !strings.Contains(out, colorHeader) {
+		t.Errorf("header key not highlighted: %q", out)
+	}
+}
+
+func TestHighlightHeadersResponse(t *testing.T) {
+	headers := []byte("HTTP/1.1 404 Not Found\r\nContent-Type: text/plain\r\n\r\n")
+	out := string(highlightHeaders(headers, false))
+	if !strings.Contains(out, colorStatus4xx) {
+		t.Errorf("status not colorized: %q", out)
+	}
+	if !strings.Contains(out, colorHeader) {
+		t.Errorf("header key not highlighted: %q", out)
+	}
+}
+
+func TestColorStatus(t *testing.T) {
+	if colorStatus(201) != colorStatus2xx {
+		t.Errorf("expected 2xx color")
+	}
+	if colorStatus(302) != colorStatus3xx {
+		t.Errorf("expected 3xx color")
+	}
+	if colorStatus(404) != colorStatus4xx {
+		t.Errorf("expected 4xx color")
+	}
+	if colorStatus(500) != colorStatus5xx {
+		t.Errorf("expected 5xx color")
+	}
+}


### PR DESCRIPTION
## Summary
- highlight JSON and XML bodies in the request/response logs
- document syntax highlighting behavior
- move highlighting helpers into highlight.go for easier maintenance

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_684bf1239860833288266e3646a209bb