### PR TITLE
Add target/port flags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,11 +40,19 @@ jobs:
           CGO_ENABLED: 0
           GO111MODULE: on
       
-      - name: Build for Windows
+      - name: Build for Windows (AMD64)
         run: go build -v -o http-proxy-logger-windows-amd64.exe
         env:
           GOOS: windows
           GOARCH: amd64
+          CGO_ENABLED: 0
+          GO111MODULE: on
+
+      - name: Build for Windows (ARM64)
+        run: go build -v -o http-proxy-logger-windows-arm64.exe
+        env:
+          GOOS: windows
+          GOARCH: arm64
           CGO_ENABLED: 0
           GO111MODULE: on
             
@@ -97,8 +105,8 @@ jobs:
           asset_name: http-proxy-logger-linux-arm64
           asset_content_type: application/octet-stream
 
-      - name: Upload Release Asset for Windows
-        id: upload-release-asset-windows
+      - name: Upload Release Asset for Windows (AMD64)
+        id: upload-release-asset-windows-amd64
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -108,6 +116,17 @@ jobs:
           asset_name: http-proxy-logger-windows-amd64.exe
           asset_content_type: application/octet-stream
       
+      - name: Upload Release Asset for Windows (ARM64)
+        id: upload-release-asset-windows-arm64
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./http-proxy-logger-windows-arm64.exe
+          asset_name: http-proxy-logger-windows-arm64.exe
+          asset_content_type: application/octet-stream
+          
       - name: Upload Release Asset for MacOS (AMD64)
         id: upload-release-asset-macos-amd64
         uses: actions/upload-release-asset@v1

--- a/README.md
+++ b/README.md
@@ -61,23 +61,29 @@ docker build -t stn1slv/http-proxy-logger .
 ## Running
 
 Set the `TARGET` environment variable to the upstream server and optionally
-`PORT` for the listen address. You can run the proxy either directly or inside
-a Docker container.
+`PORT` for the listen address. These values can also be provided with the
+`-target` and `-port` flags which override the environment.
+
+Use the `-requests` and `-responses` flags to control which messages are
+printed. Both default to `true`.
 
 ### Local execution
 
 ```bash
-TARGET=http://example.com PORT=8888 ./http-proxy-logger
+./http-proxy-logger -target http://example.com -port 8888 -responses=false
 ```
 
 ### Docker
 
 ```bash
 docker run --rm -it -p 8888:8888 \
-  -e PORT=8888 \
-  -e TARGET=http://demo7704619.mockable.io \
-  stn1slv/http-proxy-logger
+  stn1slv/http-proxy-logger \
+  -target http://demo7704619.mockable.io \
+  -port 8888
 ```
+Add `-responses=false` to log only requests or `-requests=false` to log only
+responses. Flags `-target` and `-port` may be used instead of the corresponding
+environment variables.
 
 The proxy will forward traffic to the target and log each request/response pair
 using the format shown above.


### PR DESCRIPTION
## Summary
- allow overriding env vars with `-target` and `-port` flags
- update examples and docs for new flags
- respect logging request/response flags

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684c3cae81e88332aea3eb8bf8f4b19a