### PR TITLE
Add colored timestamps and adjust response color

### DIFF
--- a/highlight.go
+++ b/highlight.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const (
@@ -28,11 +29,16 @@ const (
 	colorStatus4xx = "\033[33m"
 	colorStatus5xx = "\033[31m"
 	colorReqMarker = "\033[33m"
-	colorResMarker = "\033[36m"
+	colorResMarker = "\033[95m"
+	colorTime      = "\033[90m"
 )
 
 func wrapColor(s, color string) string {
 	return color + s + colorReset
+}
+
+func coloredTime(t time.Time) string {
+	return wrapColor(t.Format("2006/01/02 15:04:05"), colorTime)
 }
 
 func highlightJSONValue(v interface{}, indent int) string {


### PR DESCRIPTION
## Summary
- add `colorTime` constant and `coloredTime` helper
- disable default logger timestamps and print custom colored time
- log timestamps for request and response lines
- change response line color to bright magenta

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684d2fa6f79483328249efc9179539d1