### PR TITLE
Add brackets around log timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ header names, and JSON or XML bodies are highlighted for readability.
 ## Example output
 
 ```http
-2021/05/05 03:50:44 --- REQUEST 3 ---
+[2021/05/05 03:50:44] --- REQUEST 3 ---
 
 POST /mocking/contacts HTTP/1.1
 Host: demo7704619.mockable.io
@@ -26,7 +26,7 @@ X-Forwarded-For: 172.17.0.1
     "lastName": "Deviatov"
 }
 
-2021/05/05 03:50:44 --- RESPONSE 3 (201 Created) ---
+[2021/05/05 03:50:44] --- RESPONSE 3 (201 Created) ---
 
 HTTP/1.1 201 Created
 Content-Length: 68

--- a/highlight.go
+++ b/highlight.go
@@ -38,7 +38,7 @@ func wrapColor(s, color string) string {
 }
 
 func coloredTime(t time.Time) string {
-	return wrapColor(t.Format("2006/01/02 15:04:05"), colorTime)
+	return wrapColor("["+t.Format("2006/01/02 15:04:05")+"]", colorTime)
 }
 
 func highlightJSONValue(v interface{}, indent int) string {

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ func decodeBody(encoding string, body []byte) ([]byte, error) {
 
 // coloredTimeWithColor returns the formatted time string wrapped in the given color.
 func coloredTimeWithColor(t time.Time, color string) string {
-	return wrapColor(t.Format("2006/01/02 15:04:05"), color)
+	return wrapColor("["+t.Format("2006/01/02 15:04:05")+"]", color)
 }
 
 // RoundTrip implements the http.RoundTripper interface.


### PR DESCRIPTION
## Summary
- wrap timestamps in brackets for clearer log output
- adjust README example to show new format

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684fc2a65bb083328a37550a3f21967c