### PR TITLE
Xml namespace bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # HTTP Proxy Logger
 
 HTTP Proxy Logger is a small reverse proxy that prints incoming HTTP requests
-and outgoing responses to stdout. Bodies compressed with `gzip` or `deflate`
+and outgoing responses to stdout. Bodies compressed with `gzip`, `deflate`, or `br`
 are automatically decompressed in the logs so that you can easily inspect them.
 The output uses ANSI colors similar to `HTTPie`: request and response lines,
 header names, and JSON or XML bodies are highlighted for readability.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ Use the `-no-color` flag to disable colored output and remove ANSI color codes
 from the logs, useful for redirecting output to files or when colors are not
 desired.
 
+The tool automatically highlights JSON and XML bodies with syntax coloring and
+proper formatting while preserving important structural information like XML
+namespaces and namespace prefixes (e.g., `soapenv:Envelope`).
+
 ### Local execution
 
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/stn1slv/http-proxy-logger
 
 go 1.23
+
+require github.com/andybalholm/brotli v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
+github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
+github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
+github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=

--- a/highlight.go
+++ b/highlight.go
@@ -115,13 +115,7 @@ func highlightXML(data []byte) string {
 	// We need to track namespace prefixes as we encounter them
 	nsPrefixes := make(map[string]string) // maps namespace URL to prefix
 
-	// Peek ahead to check if next token is simple CharData
-	type TokenInfo struct {
-		tok xml.Token
-		err error
-	}
-
-	tokens := []TokenInfo{}
+	tokens := []xml.Token{}
 	// First pass: collect all tokens
 	for {
 		tok, err := dec.Token()
@@ -131,16 +125,14 @@ func highlightXML(data []byte) string {
 		if err != nil {
 			return string(data)
 		}
-		tokens = append(tokens, TokenInfo{xml.CopyToken(tok), err})
+		tokens = append(tokens, xml.CopyToken(tok))
 	}
 
 	justWroteStartTag := false
 	justWroteInlineText := false
 
 	for i := 0; i < len(tokens); i++ {
-		t := tokens[i]
-
-		switch tok := t.tok.(type) {
+		switch tok := tokens[i].(type) {
 		case xml.StartElement:
 			// Check for namespace declarations in attributes
 			var nsAttrs []xml.Attr
@@ -171,22 +163,22 @@ func highlightXML(data []byte) string {
 			// Check if next token is simple text (not another element)
 			hasSimpleText := false
 			if i+1 < len(tokens) {
-				if charData, ok := tokens[i+1].tok.(xml.CharData); ok {
+				if charData, ok := tokens[i+1].(xml.CharData); ok {
 					txt := strings.TrimSpace(string(charData))
 					if txt != "" {
 						// Check if the token after CharData is EndElement
 						// (or if there's whitespace CharData, check after that)
 						nextEndIdx := i + 2
 						for nextEndIdx < len(tokens) {
-							if _, ok := tokens[nextEndIdx].tok.(xml.CharData); ok {
+							if _, ok := tokens[nextEndIdx].(xml.CharData); ok {
 								// Skip whitespace-only CharData
-								if strings.TrimSpace(string(tokens[nextEndIdx].tok.(xml.CharData))) == "" {
+								if strings.TrimSpace(string(tokens[nextEndIdx].(xml.CharData))) == "" {
 									nextEndIdx++
 									continue
 								}
 								break
 							}
-							if _, isEndElement := tokens[nextEndIdx].tok.(xml.EndElement); isEndElement {
+							if _, isEndElement := tokens[nextEndIdx].(xml.EndElement); isEndElement {
 								hasSimpleText = true
 							}
 							break

--- a/json_test.go
+++ b/json_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"flag"
+	"strings"
+	"testing"
+)
+
+func TestHighlightBodyJSON(t *testing.T) {
+	// Ensure colors are enabled for this test
+	originalNoColor := noColor
+	if noColor == nil {
+		noColor = flag.Bool("no-color", false, "disable colored output")
+	}
+	defer func() { noColor = originalNoColor }()
+	*noColor = false
+
+	data := []byte(`{"name":"Alice"}`)
+	out := string(highlightBody(data, "application/json"))
+	if out == string(data) {
+		t.Fatalf("expected JSON body to be highlighted")
+	}
+	if !strings.Contains(out, colorKey) || !strings.Contains(out, colorString) {
+		t.Errorf("highlighted JSON missing colors: %q", out)
+	}
+}
+
+func TestHighlightBodyJSONWithColorsDisabled(t *testing.T) {
+	// Save original state
+	originalNoColor := noColor
+	if noColor == nil {
+		noColor = flag.Bool("no-color", false, "disable colored output")
+	}
+	defer func() { noColor = originalNoColor }()
+
+	*noColor = true
+
+	data := []byte(`{"name":"Alice"}`)
+	out := string(highlightBody(data, "application/json"))
+
+	// Should still format JSON but without colors
+	if strings.Contains(out, colorKey) || strings.Contains(out, colorString) {
+		t.Errorf("highlighted JSON with no-color should not contain color codes: %q", out)
+	}
+	// Should still contain the formatted structure
+	if !strings.Contains(out, `"name"`) || !strings.Contains(out, `"Alice"`) {
+		t.Errorf("highlighted JSON should still contain the data: %q", out)
+	}
+}
+
+func TestHighlightJSONValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		contains []string
+	}{
+		{
+			name:     "simple object",
+			input:    `{"key":"value"}`,
+			contains: []string{`"key"`, `"value"`},
+		},
+		{
+			name:     "nested object",
+			input:    `{"outer":{"inner":"value"}}`,
+			contains: []string{`"outer"`, `"inner"`, `"value"`},
+		},
+		{
+			name:     "array",
+			input:    `{"items":[1,2,3]}`,
+			contains: []string{`"items"`, "1", "2", "3"},
+		},
+		{
+			name:     "boolean and null",
+			input:    `{"bool":true,"null":null}`,
+			contains: []string{`"bool"`, "true", `"null"`, "null"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := highlightJSON([]byte(tt.input))
+			for _, expected := range tt.contains {
+				if !strings.Contains(result, expected) {
+					t.Errorf("Expected %q to contain %q", result, expected)
+				}
+			}
+		})
+	}
+}
+
+func TestHighlightJSONInvalid(t *testing.T) {
+	data := []byte(`{invalid json}`)
+	result := highlightJSON(data)
+	// Should return original data when JSON is invalid
+	if result != string(data) {
+		t.Errorf("Invalid JSON should be returned as-is, got: %q", result)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+
+	"github.com/andybalholm/brotli"
 )
 
 // reqCounter is a global atomic counter for request/response pairs.
@@ -30,7 +32,7 @@ var noColor = flag.Bool("no-color", false, "disable colored output")
 // DebugTransport is a custom http.RoundTripper that logs requests and responses.
 type DebugTransport struct{}
 
-// decodeBody decompresses the body if the encoding is gzip or deflate.
+// decodeBody decompresses the body if the encoding is gzip, deflate, or br.
 // Returns the decoded body or the original if no decoding is needed.
 func decodeBody(encoding string, body []byte) ([]byte, error) {
 	switch strings.ToLower(strings.TrimSpace(encoding)) {
@@ -47,6 +49,9 @@ func decodeBody(encoding string, body []byte) ([]byte, error) {
 			return nil, err
 		}
 		defer r.Close()
+		return io.ReadAll(r)
+	case "br":
+		r := brotli.NewReader(bytes.NewReader(body))
 		return io.ReadAll(r)
 	default:
 		return body, nil

--- a/xml_test.go
+++ b/xml_test.go
@@ -214,8 +214,22 @@ func TestXMLInlineTextFormatting(t *testing.T) {
 	}
 
 	// Check that parent elements with nested children still have proper line breaks
-	if !strings.Contains(resultStr, "<soap:Body>\n") {
-		t.Errorf("Expected '<soap:Body>' to be followed by a newline (has nested children), got:\n%s", resultStr)
+	// We check that <soap:Body> is followed by a newline, not inline with its closing tag
+	foundBodyWithNewline := false
+	for i, line := range lines {
+		if strings.Contains(line, "<soap:Body>") {
+			// If Body is on its own line (not followed immediately by </soap:Body> on same line)
+			if !strings.Contains(line, "</soap:Body>") {
+				// And if there's a next line with content
+				if i+1 < len(lines) && strings.TrimSpace(lines[i+1]) != "" {
+					foundBodyWithNewline = true
+					break
+				}
+			}
+		}
+	}
+	if !foundBodyWithNewline {
+		t.Errorf("Expected '<soap:Body>' to be followed by content on a new line (has nested children), got:\n%s", resultStr)
 	}
 
 	// Verify namespace preservation

--- a/xml_test.go
+++ b/xml_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestHighlightBodyXML(t *testing.T) {
+	// Ensure colors are enabled for this test
+	originalNoColor := noColor
+	if noColor == nil {
+		noColor = flag.Bool("no-color", false, "disable colored output")
+	}
+	defer func() { noColor = originalNoColor }()
+	*noColor = false
+
+	data := []byte(`<p>Hello</p>`)
+	out := string(highlightBody(data, "application/xml"))
+	if out == string(data) {
+		t.Fatalf("expected XML body to be highlighted")
+	}
+	if !strings.Contains(out, colorTag) {
+		t.Errorf("highlighted XML missing tag color: %q", out)
+	}
+}
+
+func TestXMLNamespacePreservation(t *testing.T) {
+	// Reset flags
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	noColor = flag.Bool("no-color", true, "disable colored output")
+
+	soapBody := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<soapenv:Body>
+<test>value</test>
+</soapenv:Body>
+</soapenv:Envelope>`)
+
+	result := highlightBody(soapBody, "text/xml")
+	resultStr := string(result)
+
+	// Check that namespace prefixes are preserved
+	if !strings.Contains(resultStr, "soapenv:Envelope") {
+		t.Errorf("Expected 'soapenv:Envelope' to be preserved in highlighted XML, got:\n%s", resultStr)
+	}
+
+	if !strings.Contains(resultStr, "soapenv:Body") {
+		t.Errorf("Expected 'soapenv:Body' to be preserved in highlighted XML, got:\n%s", resultStr)
+	}
+
+	// Check that namespace declarations are preserved
+	if !strings.Contains(resultStr, "xmlns:soapenv") {
+		t.Errorf("Expected 'xmlns:soapenv' namespace declaration to be preserved, got:\n%s", resultStr)
+	}
+
+	if !strings.Contains(resultStr, "http://schemas.xmlsoap.org/soap/envelope/") {
+		t.Errorf("Expected namespace URI to be preserved, got:\n%s", resultStr)
+	}
+
+	// Check that XML declaration is preserved
+	if !strings.Contains(resultStr, "<?xml") {
+		t.Errorf("Expected XML declaration to be preserved, got:\n%s", resultStr)
+	}
+
+	t.Logf("✓ XML namespaces and prefixes are preserved in highlighting:\n%s", resultStr)
+}
+
+func TestXMLMultipleNamespaces(t *testing.T) {
+	// Reset flags
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	noColor = flag.Bool("no-color", true, "disable colored output")
+
+	xmlBody := []byte(`<?xml version="1.0"?>
+<root xmlns:a="http://example.com/a" xmlns:b="http://example.com/b">
+<a:element1>value1</a:element1>
+<b:element2 b:attr="test">value2</b:element2>
+</root>`)
+
+	result := highlightBody(xmlBody, "application/xml")
+	resultStr := string(result)
+
+	// Check multiple namespace prefixes
+	if !strings.Contains(resultStr, "a:element1") {
+		t.Errorf("Expected 'a:element1' to be preserved, got:\n%s", resultStr)
+	}
+
+	if !strings.Contains(resultStr, "b:element2") {
+		t.Errorf("Expected 'b:element2' to be preserved, got:\n%s", resultStr)
+	}
+
+	if !strings.Contains(resultStr, "b:attr") {
+		t.Errorf("Expected 'b:attr' attribute with namespace to be preserved, got:\n%s", resultStr)
+	}
+
+	// Check namespace declarations
+	if !strings.Contains(resultStr, "xmlns:a") {
+		t.Errorf("Expected 'xmlns:a' declaration to be preserved, got:\n%s", resultStr)
+	}
+
+	if !strings.Contains(resultStr, "xmlns:b") {
+		t.Errorf("Expected 'xmlns:b' declaration to be preserved, got:\n%s", resultStr)
+	}
+
+	t.Logf("✓ Multiple XML namespaces are correctly preserved:\n%s", resultStr)
+}
+
+func TestXMLDefaultNamespace(t *testing.T) {
+	// Reset flags
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	noColor = flag.Bool("no-color", true, "disable colored output")
+
+	xmlBody := []byte(`<?xml version="1.0"?>
+<root xmlns="http://example.com/default">
+<child>value</child>
+</root>`)
+
+	result := highlightBody(xmlBody, "text/xml")
+	resultStr := string(result)
+
+	// Check that default namespace is preserved
+	if !strings.Contains(resultStr, "xmlns=") {
+		t.Errorf("Expected default namespace 'xmlns=' to be preserved, got:\n%s", resultStr)
+	}
+
+	if !strings.Contains(resultStr, "http://example.com/default") {
+		t.Errorf("Expected default namespace URI to be preserved, got:\n%s", resultStr)
+	}
+
+	t.Logf("✓ Default XML namespace is correctly preserved:\n%s", resultStr)
+}
+
+func TestHighlightXMLWithComments(t *testing.T) {
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	noColor = flag.Bool("no-color", true, "disable colored output")
+
+	xmlBody := []byte(`<?xml version="1.0"?>
+<root>
+<!-- This is a comment -->
+<child>value</child>
+</root>`)
+
+	result := highlightBody(xmlBody, "text/xml")
+	resultStr := string(result)
+
+	if !strings.Contains(resultStr, "<!-- This is a comment -->") {
+		t.Errorf("Expected XML comment to be preserved, got:\n%s", resultStr)
+	}
+}
+
+func TestHighlightXMLInvalid(t *testing.T) {
+	data := []byte(`<invalid><xml>`)
+	result := highlightXML(data)
+	// Should return original data when XML is invalid
+	if result != string(data) {
+		t.Errorf("Invalid XML should be returned as-is, got: %q", result)
+	}
+}


### PR DESCRIPTION
This pull request enhances the HTTP Proxy Logger by adding support for Brotli (`br`) compression, improving XML body highlighting to preserve namespaces and prefixes, and refactoring tests for better organization and coverage. The most significant changes are grouped below.

**New features and support:**

* Added Brotli (`br`) decompression support to both the documentation (`README.md`) and the `decodeBody` function, allowing the proxy to log HTTP bodies compressed with Brotli. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4-R4) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R18-R19) [[3]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L33-R35) [[4]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R53-R55) [[5]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R4-R5)

**Improvements to body highlighting:**

* Enhanced XML highlighting in `highlight.go` to preserve and display XML namespaces and prefixes (e.g., `soapenv:Envelope`), and improved formatting for better readability. [[1]](diffhunk://#diff-dbd5df3ea4e0be46a5ab544dfeec3e51ef9f899c2ab600db50bfe7794cfd7298R114-R119) [[2]](diffhunk://#diff-dbd5df3ea4e0be46a5ab544dfeec3e51ef9f899c2ab600db50bfe7794cfd7298L122-R280)
* Updated documentation to clarify that JSON and XML bodies are highlighted with syntax coloring and structural information, including XML namespaces.

**Testing and code organization:**

* Refactored body highlighting tests: moved JSON body highlighting tests from `highlight_test.go` to a new dedicated `json_test.go`, added more thorough coverage of JSON formatting, and improved color/no-color flag handling in tests. [[1]](diffhunk://#diff-068964e6463eabaa6a6783f391d7da735d2c6ec02576567581bceb36793c56c8R1-R98) [[2]](diffhunk://#diff-8d1e9871a9696e7f37a9d6871023345197e0c0519306925b8810fd2a0e7a70aeL10-R10) [[3]](diffhunk://#diff-8d1e9871a9696e7f37a9d6871023345197e0c0519306925b8810fd2a0e7a70aeL192-L236)
* Added or improved tests for header highlighting, color wrapping, and time formatting to ensure correct behavior with and without ANSI color codes. [[1]](diffhunk://#diff-8d1e9871a9696e7f37a9d6871023345197e0c0519306925b8810fd2a0e7a70aeR34-R57) [[2]](diffhunk://#diff-8d1e9871a9696e7f37a9d6871023345197e0c0519306925b8810fd2a0e7a70aeR73-R74) [[3]](diffhunk://#diff-8d1e9871a9696e7f37a9d6871023345197e0c0519306925b8810fd2a0e7a70aeR113-R114)

These updates make the proxy logger more robust and user-friendly, especially when inspecting compressed or complex XML/JSON payloads.