### PR TITLE
feat: add Homebrew tap support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,11 @@ jobs:
     env:
       HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
     steps:
+      - name: Check HOMEBREW_TAP_TOKEN
+        if: env.HOMEBREW_TAP_TOKEN == ''
+        run: |
+          echo "::warning::HOMEBREW_TAP_TOKEN secret is not set — skipping Homebrew formula update"
+
       - name: Update Homebrew formula
         if: env.HOMEBREW_TAP_TOKEN != ''
         env:
@@ -105,6 +110,8 @@ jobs:
             version "${VERSION}"
             license "MIT"
 
+            depends_on :macos
+
             on_macos do
               if Hardware::CPU.intel?
                 url "https://github.com/stn1slv/http-proxy-logger/releases/download/${TAG}/http-proxy-logger_darwin_amd64.tar.gz"
@@ -129,12 +136,20 @@ jobs:
           # Push to homebrew-tap via GitHub API
           FORMULA_CONTENT=$(base64 -w 0 formula.rb)
 
-          # Check if file already exists to get its SHA
-          FILE_SHA=$(curl -sSL --retry 3 --retry-delay 5 \
+          # Check if file already exists to get its SHA (404 = new file, other errors = fail)
+          HTTP_CODE=$(curl -sSL --retry 3 --retry-delay 5 -w '%{http_code}' -o /tmp/tap-response.json \
             -H "Authorization: token ${HOMEBREW_TAP_TOKEN}" \
             -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/stn1slv/homebrew-tap/contents/Formula/http-proxy-logger.rb" 2>/dev/null \
-            | jq -r '.sha // empty' 2>/dev/null || true)
+            "https://api.github.com/repos/stn1slv/homebrew-tap/contents/Formula/http-proxy-logger.rb")
+          if [ "$HTTP_CODE" = "200" ]; then
+            FILE_SHA=$(jq -r '.sha' /tmp/tap-response.json)
+          elif [ "$HTTP_CODE" = "404" ]; then
+            FILE_SHA=""
+          else
+            echo "::error::GitHub API returned HTTP ${HTTP_CODE} when checking existing formula"
+            cat /tmp/tap-response.json
+            exit 1
+          fi
 
           # Build request body
           if [ -n "$FILE_SHA" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,13 +38,23 @@ jobs:
           for platform in "${platforms[@]}"; do
             GOOS="${platform%/*}"
             GOARCH="${platform#*/}"
-            output="http-proxy-logger-${GOOS}-${GOARCH}"
+            binary="http-proxy-logger"
             if [ "$GOOS" = "windows" ]; then
-              output="${output}.exe"
+              binary="${binary}.exe"
             fi
-            echo "Building ${output}..."
+            echo "Building ${GOOS}/${GOARCH}..."
             CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" \
-              go build -ldflags="-s -w" -o "$output"
+              go build -ldflags="-s -w" -o "$binary"
+
+            # Create tarball
+            tar czf "http-proxy-logger_${GOOS}_${GOARCH}.tar.gz" "$binary"
+
+            # Rename raw binary for backward compatibility
+            raw="http-proxy-logger-${GOOS}-${GOARCH}"
+            if [ "$GOOS" = "windows" ]; then
+              raw="${raw}.exe"
+            fi
+            mv "$binary" "$raw"
           done
 
       - name: Create release
@@ -58,3 +68,81 @@ jobs:
             http-proxy-logger-windows-arm64.exe
             http-proxy-logger-darwin-amd64
             http-proxy-logger-darwin-arm64
+            http-proxy-logger_*.tar.gz
+
+  update-homebrew:
+    needs: release
+    runs-on: ubuntu-latest
+    env:
+      HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+    steps:
+      - name: Update Homebrew formula
+        if: env.HOMEBREW_TAP_TOKEN != ''
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          # Extract version: v.1.2.3 → 1.2.3 or v1.2.3 → 1.2.3
+          VERSION="${TAG#v}"
+          VERSION="${VERSION#.}"
+
+          # Download darwin tarballs and compute SHA256
+          for arch in amd64 arm64; do
+            curl -fsSL "https://github.com/stn1slv/http-proxy-logger/releases/download/${TAG}/http-proxy-logger_darwin_${arch}.tar.gz" \
+              -o "darwin_${arch}.tar.gz"
+          done
+          SHA_AMD64=$(sha256sum darwin_amd64.tar.gz | cut -d' ' -f1)
+          SHA_ARM64=$(sha256sum darwin_arm64.tar.gz | cut -d' ' -f1)
+
+          # Generate formula
+          cat > formula.rb <<FORMULA
+          # typed: false
+          # frozen_string_literal: true
+
+          class HttpProxyLogger < Formula
+            desc "HTTP reverse-proxy with colored request/response logging"
+            homepage "https://github.com/stn1slv/http-proxy-logger"
+            version "${VERSION}"
+            license "MIT"
+
+            if Hardware::CPU.intel?
+              url "https://github.com/stn1slv/http-proxy-logger/releases/download/${TAG}/http-proxy-logger_darwin_amd64.tar.gz"
+              sha256 "${SHA_AMD64}"
+            end
+            if Hardware::CPU.arm?
+              url "https://github.com/stn1slv/http-proxy-logger/releases/download/${TAG}/http-proxy-logger_darwin_arm64.tar.gz"
+              sha256 "${SHA_ARM64}"
+            end
+
+            def install
+              bin.install "http-proxy-logger"
+            end
+
+            test do
+              assert_match "Usage", shell_output("#{bin}/http-proxy-logger -help 2>&1", 2)
+            end
+          end
+          FORMULA
+
+          # Push to homebrew-tap via GitHub API
+          FORMULA_CONTENT=$(base64 -w 0 formula.rb)
+
+          # Check if file already exists to get its SHA
+          EXISTING=$(curl -fsSL \
+            -H "Authorization: token ${HOMEBREW_TAP_TOKEN}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/stn1slv/homebrew-tap/contents/Formula/http-proxy-logger.rb" 2>/dev/null || echo "")
+
+          FILE_SHA=$(echo "$EXISTING" | grep -o '"sha":"[^"]*"' | head -1 | cut -d'"' -f4)
+
+          # Build request body
+          if [ -n "$FILE_SHA" ]; then
+            BODY="{\"message\":\"chore: update http-proxy-logger to ${VERSION}\",\"content\":\"${FORMULA_CONTENT}\",\"sha\":\"${FILE_SHA}\"}"
+          else
+            BODY="{\"message\":\"feat: add http-proxy-logger ${VERSION}\",\"content\":\"${FORMULA_CONTENT}\"}"
+          fi
+
+          curl -fsSL -X PUT \
+            -H "Authorization: token ${HOMEBREW_TAP_TOKEN}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/stn1slv/homebrew-tap/contents/Formula/http-proxy-logger.rb" \
+            -d "$BODY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,8 @@ jobs:
 
           # Download darwin tarballs and compute SHA256
           for arch in amd64 arm64; do
-            curl -fsSL "https://github.com/stn1slv/http-proxy-logger/releases/download/${TAG}/http-proxy-logger_darwin_${arch}.tar.gz" \
+            curl -fsSL --retry 3 --retry-delay 5 \
+              "https://github.com/stn1slv/http-proxy-logger/releases/download/${TAG}/http-proxy-logger_darwin_${arch}.tar.gz" \
               -o "darwin_${arch}.tar.gz"
           done
           SHA_AMD64=$(sha256sum darwin_amd64.tar.gz | cut -d' ' -f1)
@@ -104,13 +105,15 @@ jobs:
             version "${VERSION}"
             license "MIT"
 
-            if Hardware::CPU.intel?
-              url "https://github.com/stn1slv/http-proxy-logger/releases/download/${TAG}/http-proxy-logger_darwin_amd64.tar.gz"
-              sha256 "${SHA_AMD64}"
-            end
-            if Hardware::CPU.arm?
-              url "https://github.com/stn1slv/http-proxy-logger/releases/download/${TAG}/http-proxy-logger_darwin_arm64.tar.gz"
-              sha256 "${SHA_ARM64}"
+            on_macos do
+              if Hardware::CPU.intel?
+                url "https://github.com/stn1slv/http-proxy-logger/releases/download/${TAG}/http-proxy-logger_darwin_amd64.tar.gz"
+                sha256 "${SHA_AMD64}"
+              end
+              if Hardware::CPU.arm?
+                url "https://github.com/stn1slv/http-proxy-logger/releases/download/${TAG}/http-proxy-logger_darwin_arm64.tar.gz"
+                sha256 "${SHA_ARM64}"
+              end
             end
 
             def install
@@ -127,12 +130,11 @@ jobs:
           FORMULA_CONTENT=$(base64 -w 0 formula.rb)
 
           # Check if file already exists to get its SHA
-          EXISTING=$(curl -fsSL \
+          FILE_SHA=$(curl -fsSL --retry 3 --retry-delay 5 \
             -H "Authorization: token ${HOMEBREW_TAP_TOKEN}" \
             -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/stn1slv/homebrew-tap/contents/Formula/http-proxy-logger.rb" 2>/dev/null || echo "")
-
-          FILE_SHA=$(echo "$EXISTING" | grep -o '"sha":"[^"]*"' | head -1 | cut -d'"' -f4)
+            "https://api.github.com/repos/stn1slv/homebrew-tap/contents/Formula/http-proxy-logger.rb" 2>/dev/null \
+            | jq -r '.sha // empty')
 
           # Build request body
           if [ -n "$FILE_SHA" ]; then
@@ -141,7 +143,7 @@ jobs:
             BODY="{\"message\":\"feat: add http-proxy-logger ${VERSION}\",\"content\":\"${FORMULA_CONTENT}\"}"
           fi
 
-          curl -fsSL -X PUT \
+          curl -fsSL --retry 3 --retry-delay 5 -X PUT \
             -H "Authorization: token ${HOMEBREW_TAP_TOKEN}" \
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/repos/stn1slv/homebrew-tap/contents/Formula/http-proxy-logger.rb" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
             end
 
             test do
-              assert_match "Usage", shell_output("#{bin}/http-proxy-logger -help 2>&1", 2)
+              assert_match "Usage", shell_output("#{bin}/http-proxy-logger -help 2>&1")
             end
           end
           FORMULA
@@ -130,11 +130,11 @@ jobs:
           FORMULA_CONTENT=$(base64 -w 0 formula.rb)
 
           # Check if file already exists to get its SHA
-          FILE_SHA=$(curl -fsSL --retry 3 --retry-delay 5 \
+          FILE_SHA=$(curl -sSL --retry 3 --retry-delay 5 \
             -H "Authorization: token ${HOMEBREW_TAP_TOKEN}" \
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/repos/stn1slv/homebrew-tap/contents/Formula/http-proxy-logger.rb" 2>/dev/null \
-            | jq -r '.sha // empty')
+            | jq -r '.sha // empty' 2>/dev/null || true)
 
           # Build request body
           if [ -n "$FILE_SHA" ]; then

--- a/README.md
+++ b/README.md
@@ -42,17 +42,23 @@ X-Cloud-Trace-Context: 83ac5937ae7ba8f3ef96ee941227b1b0
 }
 ```
 
-## Building
+## Installation
 
-The project requires **Go 1.23**.
+### Homebrew (macOS)
 
-### Build a binary
+```bash
+brew install stn1slv/tap/http-proxy-logger
+```
+
+### From source
+
+The project requires **Go 1.26+**.
 
 ```bash
 go build -o http-proxy-logger
 ```
 
-### Build a Docker image
+### Docker image
 
 ```bash
 docker build -t stn1slv/http-proxy-logger .

--- a/README.md
+++ b/README.md
@@ -50,18 +50,33 @@ X-Cloud-Trace-Context: 83ac5937ae7ba8f3ef96ee941227b1b0
 brew install stn1slv/tap/http-proxy-logger
 ```
 
+### Download binary (Linux / Windows / macOS)
+
+Pre-built binaries for all platforms are available on the
+[Releases](https://github.com/stn1slv/http-proxy-logger/releases/latest) page.
+
+Download the binary for your OS/architecture, make it executable, and move it
+to a directory in your `PATH`:
+
+```bash
+# Example for Linux amd64
+curl -fsSL https://github.com/stn1slv/http-proxy-logger/releases/latest/download/http-proxy-logger-linux-amd64 -o http-proxy-logger
+chmod +x http-proxy-logger
+sudo mv http-proxy-logger /usr/local/bin/
+```
+
+### Docker
+
+```bash
+docker pull stn1slv/http-proxy-logger
+```
+
 ### From source
 
-The project requires **Go 1.26+**.
+Requires **Go 1.26+**.
 
 ```bash
 go build -o http-proxy-logger
-```
-
-### Docker image
-
-```bash
-docker build -t stn1slv/http-proxy-logger .
 ```
 
 ## Running


### PR DESCRIPTION
## Summary
- Release workflow now produces `.tar.gz` archives alongside raw binaries
- Added `update-homebrew` job that auto-updates the formula in `stn1slv/homebrew-tap` on each release (computes SHA256, pushes via GitHub API)
- Updated README with Homebrew installation instructions

## Setup
Requires `HOMEBREW_TAP_TOKEN` secret (already configured) — a PAT with `repo` scope for pushing to `stn1slv/homebrew-tap`.

## Test plan
- [ ] Merge and tag a new release
- [ ] Verify `.tar.gz` assets appear in the GitHub release
- [ ] Verify the formula is auto-updated in `stn1slv/homebrew-tap`
- [ ] Run `brew install stn1slv/tap/http-proxy-logger` and confirm `http-proxy-logger -help` works
